### PR TITLE
Add FastAPI image generator

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,48 @@
+"""FastAPI app to generate images via OpenAI's image endpoint.
+
+How to run:
+    pip install fastapi httpx "uvicorn[standard]" jinja2
+    export OPENAI_API_KEY=your-key
+    uvicorn main:app --reload
+"""
+import os
+import httpx
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+OPENAI_KEY = os.environ.get("OPENAI_API_KEY")
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+client = httpx.AsyncClient(timeout=5)
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    # Show the main page with the pre-filled prompt
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "img_url": "",
+            "default_prompt": "A futuristic city skyline in synthwave neon at dusk",
+        },
+    )
+
+@app.post("/generate")
+async def generate(prompt: str = Form(...)):
+    # Send the prompt to OpenAI and return the resulting image URL
+    headers = {"Authorization": f"Bearer {OPENAI_KEY}"}
+    payload = {"prompt": prompt, "n": 1, "size": "512x512"}
+    resp = await client.post(
+        "https://api.openai.com/v1/images/generations",
+        json=payload,
+        headers=headers,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return {"url": data["data"][0]["url"]}
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    await client.aclose()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>OpenAI Image Generator</title>
+</head>
+<body>
+    <h1>OpenAI Image Generator</h1>
+    <form id="prompt-form">
+        <input type="text" name="prompt" id="prompt" style="width:60%" value="{{ default_prompt }}">
+        <button type="submit">Generate</button>
+    </form>
+    <p><img id="result" style="max-width:512px"></p>
+    <script>
+    document.getElementById('prompt-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const resp = await fetch('/generate', { method: 'POST', body: formData });
+        if (resp.ok) {
+            const data = await resp.json();
+            document.getElementById('result').src = data.url;
+        }
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create FastAPI app using OpenAI image generation endpoint
- add simple HTML form template with fetch logic

## Testing
- `python -m pip list | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68408e14711883219775ab97fd925868